### PR TITLE
Auto-expand by URL, highlight on scroll

### DIFF
--- a/src/js/jquery.a11yTree.js
+++ b/src/js/jquery.a11yTree.js
@@ -41,6 +41,7 @@
             this.attachToggle($tree);
             this.addMouseNav($tree);
             this.addKeyBoardNav($tree);
+            this.highlightByUrlAndFragment($tree, location.pathname, location.hash);
         },
         addIdToTreeLabels: function ($tree) {
             var self = this;
@@ -303,6 +304,13 @@
                 id = $listItem.data(ITEM_ID_DATA_ATTR) || $list.parent(LIST_ITEM_SELECTOR).attr(ID_ATTR_NAME);
             }
             return id + '-' + $list.children(LIST_ITEM_SELECTOR).index($listItem);
+        },
+        highlightByUrlAndFragment : function($tree, pathName, fragment) {
+            var relevantAnchor = $tree.find('a[href*="' + pathName + fragment + '"]');
+            if(relevantAnchor.length === 1) {
+                this.expand(relevantAnchor.parents('li'));
+                this.focusOn(relevantAnchor.closest('li'), $tree);
+            }
         }
     };
 

--- a/src/js/jquery.a11yTree.js
+++ b/src/js/jquery.a11yTree.js
@@ -312,7 +312,7 @@
             return id + '-' + $list.children(LIST_ITEM_SELECTOR).index($listItem);
         },
         highlightByUrlAndFragment : function($tree, pathName, fragment) {
-            var relevantAnchor = $tree.find('a[href*="' + pathName + fragment + '"]');
+            var relevantAnchor = $tree.find('a[href*="' + pathName + fragment + '"]:first');
             if(relevantAnchor.length === 1) {
                 this.expand(relevantAnchor.parents('li'));
                 this.focusOn(relevantAnchor.closest('li'), $tree);

--- a/src/js/jquery.a11yTree.js
+++ b/src/js/jquery.a11yTree.js
@@ -327,7 +327,7 @@
                 var link = this;
                 var fragment =link.hash;
                 var targetElm = $(fragment) || $(document).find('a[name="' + fragment.substr(1) + '"]');
-                if (targetElm) {
+                if (targetElm.length) {
                     samePageLinks.push({
                         elm: targetElm,
                         link: link,


### PR DESCRIPTION
Hi, here are some suggested enhancements (two, perhaps I ought to make different PRs)

One change will mark a menu entry active when the page is loaded (and expand parents) if the link references the current address.

The second improves handling of document-internal #anchor links by setting aria-selected=true on such links when the content they refer to is scrolled into the viewport.

I hope you will consider these changes @longmatthewh !